### PR TITLE
Some escape_mapper suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ CTAGS
 tools/http_load/http_load
 tools/jtest/jtest
 tools/trafficserver.pc
+tools/escape_mapper/escape_mapper
 
 BUILDS
 DEBUG

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -296,6 +296,8 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
   // historically this is what the traffic_server has done.
   // Note that we leave codes beyond 127 unmodified.
   //
+  // NOTE: any updates to this table should result in an update to:
+  // tools/escape_mapper/escape_mapper.cc.
   static const unsigned char codes_to_escape[32] = {
     0xFF, 0xFF, 0xFF,
     0xFF,             // control

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -60,7 +60,7 @@ else
 noinst_PROGRAMS += escape_mapper/escape_mapper
 endif
 
-escape_mapper_escape_mapper_SOURCES = escape_mapper/escape_mapper.c
+escape_mapper_escape_mapper_SOURCES = escape_mapper/escape_mapper.cc
 
 all-am: Makefile $(PROGRAMS) $(SCRIPTS) $(DATA)
 	@sed "s/ -fPIE//" tsxs > tsxs.new


### PR DESCRIPTION
A few tweaks to escape_mapper:

1. Add the binary to gitignore
2. Add a NOTE requesting changies to LogUtils.cc codes_to_escape to
   update the tool.
3. Convert escape_mapper to C++.